### PR TITLE
feat: add token_type variable. Support unique token URL iss

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -7,10 +7,14 @@
 | 1.x   | :warning: |
 | 2.x   | :white_check_mark: |
 
+:x: : This version is no longer supported.
+
 :warning: : Will patch critical security issues, but no longer actively developed.
 
 :white_check_mark: : Actively supported
 
 ## Reporting a Vulnerability
 
-Report any potential security issues via our Vulnerability Disclosure Program at: <https://hackerone.com/digitalocean>.
+This open source project is not eligible for bounty rewards, but we appreciate any disclosures that help us improve the security of our products.
+
+To report a potential security issue, please [privately report a security vulnerability](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing/privately-reporting-a-security-vulnerability).

--- a/main.tf
+++ b/main.tf
@@ -37,4 +37,5 @@ resource "vault_jwt_auth_backend_role" "github_oidc_role" {
 
   token_policies = each.value.vault_policies
   token_ttl      = each.value.ttl != null ? each.value.ttl : var.default_ttl
+  token_type     = var.token_type
 }

--- a/test/main.tf
+++ b/test/main.tf
@@ -1,6 +1,8 @@
 module "github_oidc" {
   source = "../"
 
+  github_identity_provider = "https://token.actions.githubusercontent.com/digitalocean"
+
   oidc_bindings = [
     {
       audience : "https://github.com/digitalocean",

--- a/variables.tf
+++ b/variables.tf
@@ -12,7 +12,7 @@ variable "default_user_claim" {
 
 variable "github_identity_provider" {
   type        = string
-  description = "The JWT authentication URL used for the GitHub OIDC trust configuration. This should not be modified unless you are running GitHub Enterprise Server, in which case you should provide a URL in the format: `https://HOSTNAME/_services/token`. This requires GitHub Enterprise Server version 3.5 or higher. See <https://docs.github.com/en/enterprise-server@latest/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-hashicorp-vault#adding-the-identity-provider-to-hashicorp-vault>."
+  description = "The JWT authentication URL used for the GitHub OIDC trust configuration. If you are an Enteprise Cloud account, you should configure a [unique token URL](https://docs.github.com/en/enterprise-cloud@latest/actions/deployment/security-hardening-your-deployments/about-security-hardening-with-openid-connect#switching-to-a-unique-token-url) and set the result on this variable. If you are an Enterprise Server organization, you should provide a URL in the format: `https://HOSTNAME/_services/token`. This requires GitHub Enterprise Server version 3.5 or higher. See <https://docs.github.com/en/enterprise-server@latest/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-hashicorp-vault#adding-the-identity-provider-to-hashicorp-vault>."
   default     = "https://token.actions.githubusercontent.com"
 }
 
@@ -51,4 +51,10 @@ variable "oidc_bindings" {
       `ttl`: **Optional**. The default incremental time-to-live for the generated token, in seconds. Defaults to the `default_ttl` value but can be individually specified per binding with this value.
 
     EOT
+}
+
+variable "token_type" {
+  type        = string
+  default     = "batch"
+  description = "The type of token to generate. This can be either `batch` or `service`. See <https://developer.hashicorp.com/vault/api-docs/auth/jwt#token_type> for more information."
 }


### PR DESCRIPTION
Document support for and recommend enterprise cloud customers set a unique token URL to customize their bound issuer.

Also enables modifying the `token_type` by exposing an end-user variable. Defaults to batch tokens given intended use case.

Configures the CI testing in this repository to use DigitalOcean's unique token URL. ~This should initially fail until I enable the unique token URL on our account tomorrow.~ Done

Closes #89 
